### PR TITLE
fixing nit in qiskit optimizer interface

### DIFF
--- a/src/python/qeqiskit/optimizer/optimizer.py
+++ b/src/python/qeqiskit/optimizer/optimizer.py
@@ -65,7 +65,7 @@ class QiskitOptimizer(Optimizer):
         ):
             gradient_function = cost_function.gradient
 
-        solution, value, nit = optimizer.optimize(
+        solution, value, _ = optimizer.optimize(
             num_vars=number_of_variables,
             objective_function=cost_function_wrapper,
             initial_point=initial_params,
@@ -78,6 +78,11 @@ class QiskitOptimizer(Optimizer):
         else:
             nfev = cost_function_wrapper.number_of_calls
             history = []
+
+        if self.method == "ADAM" or self.method == "AMSGRAD":
+            nit = optimizer._t
+        else:
+            nit = optimizer._maxiter
 
         return optimization_result(
             opt_value=value,


### PR DESCRIPTION
I have noticed that the SPSA optimizer is hard-coded by qiskit to return `None `in the slot were we expect `nit `.  The ADAM optimizer instead returns `nfev` which instead we calculate on our own further below. This fix is for the correct value for `nit`.