### PR TITLE
import from qeqiskit.noise should be able to access all the functions…

### DIFF
--- a/src/python/qeqiskit/noise/__init__.py
+++ b/src/python/qeqiskit/noise/__init__.py
@@ -1,1 +1,1 @@
-from .basic import get_qiskit_noise_model
+from .basic import *


### PR DESCRIPTION
… in basic.py; otherwise `steps/noise.py` is not usable.