### PR TITLE
Adding handling for backend job limits

### DIFF
--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -297,13 +297,13 @@ class QiskitBackend(QuantumBackend):
 
         while True:
             try:
-                execute(
+                job = execute(
                     batch,
                     self.device,
                     shots=n_samples,
                     optimization_level=self.optimization_level,
                 )
-                break
+                return job
             except IBMQBackendJobLimitError:
                 print(f"Job limit reached. Retrying in {self.retry_delay_seconds}s.")
                 sleep(self.retry_delay_seconds)

--- a/src/python/qeqiskit/backend/backend_test.py
+++ b/src/python/qeqiskit/backend/backend_test.py
@@ -77,15 +77,35 @@ class TestQiskitBackend(QuantumBackendTests):
             [circuit.copy("circuit3"), circuit.copy("circuit4")],
         ]
         multiplicities = [3, 1]
-        jobs = [execute(batch, backend.device, shots=10,) for batch in batches]
+        jobs = [
+            backend.execute_with_retries(
+                batch,
+                10,
+            )
+            for batch in batches
+        ]
 
         circuit = self.x_cnot_circuit()
         measurements_set = backend.aggregregate_measurements(
-            jobs, batches, multiplicities,
+            jobs,
+            batches,
+            multiplicities,
         )
 
-        assert measurements_set[0].bitstrings == [(1, 0, 0),] * 30
-        assert measurements_set[1].bitstrings == [(1, 0, 0),] * 10
+        assert (
+            measurements_set[0].bitstrings
+            == [
+                (1, 0, 0),
+            ]
+            * 30
+        )
+        assert (
+            measurements_set[1].bitstrings
+            == [
+                (1, 0, 0),
+            ]
+            * 10
+        )
         assert len(measurements_set) == 2
 
     def test_run_circuitset_and_measure(self, backend):
@@ -105,6 +125,25 @@ class TestQiskitBackend(QuantumBackendTests):
             #   the one we expect)
             counts = measurements.get_counts()
             assert max(counts, key=counts.get) == "100"
+
+    def test_execute_with_retries(self, backend):
+        # Given
+        circuit = self.x_cnot_circuit()
+        n_samples = 100
+        num_jobs = backend.device.job_limit().maximum_jobs + 1
+
+        # When
+        jobs = [
+            backend.execute_with_retries([circuit], n_samples) for _ in range(num_jobs)
+        ]
+
+        # Then
+
+        # The correct number of jobs were submitted
+        assert len(jobs) == num_jobs
+
+        # Each job has a unique ID
+        assert len(set([job.job_id() for job in jobs])) == num_jobs
 
     def test_run_circuitset_and_measure_split_circuits_and_jobs(self, backend):
         # Given

--- a/src/python/qeqiskit/backend/backend_test.py
+++ b/src/python/qeqiskit/backend/backend_test.py
@@ -128,8 +128,8 @@ class TestQiskitBackend(QuantumBackendTests):
 
     def test_execute_with_retries(self, backend):
         # Given
-        circuit = self.x_cnot_circuit()
-        n_samples = 100
+        circuit = self.x_cnot_circuit().to_qiskit()
+        n_samples = 10
         num_jobs = backend.device.job_limit().maximum_jobs + 1
 
         # When


### PR DESCRIPTION
This updates the IBMQ backend to periodically retry job submissions when the backend job limit is reached. The time between retries defaults to 60 seconds but can be configured with the `retry_delay_seconds` attribute. The retries will abort after a number of seconds given by the `retry_timeout_seconds` attribute, if it is not `None`. The default timeout is 24 hours. 