### PR TITLE
Updating simulator integration to use inherited run circuitset method

### DIFF
--- a/src/python/qeqiskit/simulator/simulator_test.py
+++ b/src/python/qeqiskit/simulator/simulator_test.py
@@ -243,9 +243,6 @@ class TestQiskitSimulator(QuantumSimulatorTests):
         with pytest.raises(ValueError):
             simulator.run_circuit_and_measure(circuit, 2)
 
-    def test_run_circuitset_and_measure_n_samples(self, backend):
-        pytest.xfail()
-
 
 class TestQiskitSimulatorGates(QuantumSimulatorGatesTest):
     pass


### PR DESCRIPTION
By using the inherited `run_circuitset_and_measure` method, this will allow the simulator integration to support the `n_samples` argument.