### PR TITLE
Migrate backend to new circuits

### DIFF
--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -135,13 +135,11 @@ class QiskitBackend(QuantumBackend):
             n_samples = (self.n_samples,) * len(circuitset)
 
         for n_samples_for_circuit, circuit in zip(n_samples, circuitset):
-            # num_qubits = len(circuit.qubits)
-
             ibmq_circuit = export_to_qiskit(circuit)
-            # TODO: replace ranges with lists because Qiskit's docs require tuple or list
-            ibmq_circuit.barrier(range(circuit.n_qubits))
+            full_qubit_indices = list(range(circuit.n_qubits))
+            ibmq_circuit.barrier(full_qubit_indices)
             ibmq_circuit.add_register(ClassicalRegister(size=circuit.n_qubits))
-            ibmq_circuit.measure(range(circuit.n_qubits), range(circuit.n_qubits))
+            ibmq_circuit.measure(full_qubit_indices, full_qubit_indices)
 
             multiplicities.append(math.ceil(n_samples_for_circuit / self.max_shots))
 

--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -8,12 +8,9 @@ from qiskit.providers.ibmq.exceptions import IBMQAccountError
 from qiskit.result import Counts
 from qiskit.providers.ibmq.job import IBMQJob
 from qiskit.providers.ibmq.exceptions import IBMQBackendJobLimitError
-from openfermion.ops import IsingOperator
-from zquantum.core.openfermion import change_operator_type
 from zquantum.core.interfaces.backend import QuantumBackend
 from zquantum.core.circuit import Circuit
 from zquantum.core.measurement import (
-    expectation_values_to_real,
     Measurements,
 )
 from typing import List, Optional, Tuple

--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -46,13 +46,12 @@ class QiskitBackend(QuantumBackend):
             group: IBMQ group
             project: IBMQ project
             api_token: IBMQ Api Token
-            readout_correction: indication of whether or not to use basic readout correction
-            optimization_level: optimization level for the default qiskit transpiler (0, 1, 2, or 3)
-            retry_delay_seconds: Number of seconds to wait to resubmit a job when backend job limit is reached.
+            readout_correction: flag of whether or not to use basic readout correction
+            optimization_level: optimization level for the default qiskit transpiler (0,
+                1, 2, or 3).
+            retry_delay_seconds: Number of seconds to wait to resubmit a job when backend
+                job limit is reached.
             retry_timeout_seconds: Number of seconds to wait
-
-        Returns:
-            qeqiskit.backend.QiskitBackend
         """
         super().__init__(n_samples=n_samples)
         self.device_name = device_name
@@ -61,9 +60,9 @@ class QiskitBackend(QuantumBackend):
             try:
                 IBMQ.enable_account(api_token)
             except IBMQAccountError as e:
-                if (
-                    e.message
-                    != "An IBM Quantum Experience account is already in use for the session."
+                if e.message != (
+                    "An IBM Quantum Experience account is already in use "
+                    "for the session."
                 ):
                     raise RuntimeError(e)
 
@@ -243,7 +242,8 @@ class QiskitBackend(QuantumBackend):
             if self.readout_correction:
                 combined_counts = self.apply_readout_correction(combined_counts, kwargs)
 
-            # qiskit counts object maps bitstrings in reversed order to ints, so we must flip the bitstrings
+            # qiskit counts object maps bitstrings in reversed order to ints, so we must
+            # flip the bitstrings
             reversed_counts = {}
             for bitstring in combined_counts.keys():
                 reversed_counts[bitstring[::-1]] = int(combined_counts[bitstring])
@@ -323,7 +323,8 @@ class QiskitBackend(QuantumBackend):
                     elapsed_time_seconds = time.time() - start_time
                     if elapsed_time_seconds > self.retry_timeout_seconds:
                         raise RuntimeError(
-                            f"Failed to submit job in {elapsed_time_seconds}s due to backend job limit."
+                            f"Failed to submit job in {elapsed_time_seconds}s due to "
+                            "backend job limit."
                         )
                 print(f"Job limit reached. Retrying in {self.retry_delay_seconds}s.")
                 time.sleep(self.retry_delay_seconds)


### PR DESCRIPTION
(paired with @dexter2206)

Extends Backend implementation to support new circuits, according to interface additions from zapatacomputing/z-quantum-core#277.