### PR TITLE
ZQS-731 fix unittests by switching to ibmq_santiago device

### DIFF
--- a/tests/qeqiskit/noise/basic_test.py
+++ b/tests/qeqiskit/noise/basic_test.py
@@ -17,7 +17,7 @@ from qeqiskit.noise.basic import (
 class TestBasic(unittest.TestCase):
     def setUp(self):
         self.ibmq_api_token = os.getenv("ZAPATA_IBMQ_API_TOKEN")
-        self.all_devices = ["ibmqx2"]
+        self.all_devices = ["ibmq_santiago"]
         self.T_1 = 10e-7
         self.T_2 = 30e-7
         self.t_step = 10e-9

--- a/tests/qeqiskit/simulator/simulator_test.py
+++ b/tests/qeqiskit/simulator/simulator_test.py
@@ -60,7 +60,7 @@ def sampling_simulator(request):
 def noisy_simulator(request):
     ibmq_api_token = os.getenv("ZAPATA_IBMQ_API_TOKEN")
     noise_model, connectivity = get_qiskit_noise_model(
-        "ibmqx2", api_token=ibmq_api_token
+        "ibmq_santiago", api_token=ibmq_api_token
     )
 
     return QiskitSimulator(
@@ -175,7 +175,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
     def test_optimization_level_of_transpiler(self):
         # Given
         noise_model, connectivity = get_qiskit_noise_model(
-            "ibmqx2", api_token=os.getenv("ZAPATA_IBMQ_API_TOKEN")
+            "ibmq_santiago", api_token=os.getenv("ZAPATA_IBMQ_API_TOKEN")
         )
         n_samples = 8192
         simulator = QiskitSimulator(


### PR DESCRIPTION
Since the ibmqx2 device we used for obtaining noise models is no longer available (for confirmation see Qiskit's slack), we need to switch to another device. It seems that ibmq_santiago works just fine for our purposes.