### PR TITLE
fixed the inconsistent parameter name in run_circuitset_and_measure

### DIFF
--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -237,7 +237,7 @@ class QiskitBackend(QuantumBackend):
 
     def run_circuitset_and_measure(
         self,
-        circuitset: List[Circuit],
+        circuits: List[Circuit],
         n_samples: List[int],
     ) -> List[Measurements]:
         """Run a set of circuits and measure a certain number of bitstrings.
@@ -256,7 +256,7 @@ class QiskitBackend(QuantumBackend):
             experiments,
             n_samples_for_experiments,
             multiplicities,
-        ) = self.transform_circuitset_to_ibmq_experiments(circuitset, n_samples)
+        ) = self.transform_circuitset_to_ibmq_experiments(circuits, n_samples)
         batches, n_samples_for_batches = self.batch_experiments(
             experiments, n_samples_for_experiments
         )

--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -266,7 +266,7 @@ class QiskitBackend(QuantumBackend):
             for n_samples, batch in zip(n_samples_for_batches, batches)
         ]
 
-        self.number_of_circuits_run += len(circuitset)
+        self.number_of_circuits_run += len(circuits)
         self.number_of_jobs_run += len(batches)
 
         return self.aggregregate_measurements(jobs, batches, multiplicities)


### PR DESCRIPTION
I am submitting this PR because having different parameter names (`circuits` vs `circuitset`) between for the  **same method** (`run_circuitset_and_measure`) in `QiskitBackend` and `QiskitSimulator` (unless there is a good reason that I'm not aware of) is driving me crazy. Sorry :) 