### PR TITLE
Zqs 781/fix depreciated qiskit backends

### DIFF
--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -32,6 +32,12 @@ class QiskitBackend(QuantumBackend):
         """Get a qiskit QPU that adheres to the
         zquantum.core.interfaces.backend.QuantumBackend
 
+        qiskit currently offers 2 types of qasm simulators:
+        1. qasm_simulator - a local simulator that is depreciated.
+        2. IBMQ_qasm_simulator - a remote simulator.
+        All implementation of qasm_simulator have been removed since it's depreciation
+        but IBMQ_qasm_simulator is still tested by this module.
+
         Args:
             device_name: the name of the device
             hub: IBMQ hub

--- a/src/python/qeqiskit/simulator/simulator.py
+++ b/src/python/qeqiskit/simulator/simulator.py
@@ -108,7 +108,7 @@ class QiskitSimulator(QuantumSimulator):
         if self.device_connectivity is not None:
             coupling_map = CouplingMap(self.device_connectivity.connectivity)
 
-        if self.device_name == "statevector_simulator":
+        if self.device_name == "aer_simulator_statevector":
             wavefunction = self.get_wavefunction(circuit)
             return Measurements(sample_from_wavefunction(wavefunction, n_samples))
         else:
@@ -157,6 +157,9 @@ class QiskitSimulator(QuantumSimulator):
         coupling_map = None
         if self.device_connectivity is not None:
             coupling_map = CouplingMap(self.device_connectivity.connectivity)
+
+        if self.device_name == "aer_simulator_statevector":
+            ibmq_circuit.save_state()
 
         # Execute job to get wavefunction
         job = execute(

--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -9,6 +9,12 @@ from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from zquantum.core.circuits import CNOT, Circuit, X
 from zquantum.core.interfaces.backend_test import QuantumBackendTests
 
+# NOTE: qiskit currently offers 2 types of qasm simulators:
+# 1. qasm_simulator - a local simulator that is depreciated.
+# 2. IBMQ_qasm_simulator - a remote simulator.
+# All tests of qasm_simulator have been removed since it's depreciation
+# but IBMQ_qasm_simulator is still tested by this module.
+
 
 @pytest.fixture(
     params=[

--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -9,12 +9,6 @@ from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from zquantum.core.circuits import CNOT, Circuit, X
 from zquantum.core.interfaces.backend_test import QuantumBackendTests
 
-# NOTE: qiskit currently offers 2 types of qasm simulators:
-# 1. qasm_simulator - a local simulator that is depreciated.
-# 2. IBMQ_qasm_simulator - a remote simulator.
-# All tests of qasm_simulator have been removed since it's depreciation
-# but IBMQ_qasm_simulator is still tested by this module.
-
 
 @pytest.fixture(
     params=[

--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -212,7 +212,7 @@ class TestQiskitBackend(QuantumBackendTests):
         # Given
         num_circuits = 200
         circuit = self.x_cnot_circuit()
-        n_samples = 8193
+        n_samples = 20001
 
         # Verify that we are actually going to need to split circuits
         assert n_samples > backend.max_shots

--- a/tests/qeqiskit/simulator/simulator_test.py
+++ b/tests/qeqiskit/simulator/simulator_test.py
@@ -18,7 +18,7 @@ from zquantum.core.measurement import ExpectationValues
 @pytest.fixture(
     params=[
         {
-            "device_name": "qasm_simulator",
+            "device_name": "aer_simulator",
             "api_token": os.getenv("ZAPATA_IBMQ_API_TOKEN"),
         },
     ]
@@ -30,7 +30,7 @@ def backend(request):
 @pytest.fixture(
     params=[
         {
-            "device_name": "statevector_simulator",
+            "device_name": "aer_simulator_statevector",
         },
     ]
 )
@@ -41,10 +41,10 @@ def wf_simulator(request):
 @pytest.fixture(
     params=[
         {
-            "device_name": "qasm_simulator",
+            "device_name": "aer_simulator",
         },
         {
-            "device_name": "statevector_simulator",
+            "device_name": "aer_simulator_statevector",
         },
     ]
 )
@@ -54,7 +54,7 @@ def sampling_simulator(request):
 
 @pytest.fixture(
     params=[
-        {"device_name": "qasm_simulator", "optimization_level": 0},
+        {"device_name": "aer_simulator", "optimization_level": 0},
     ]
 )
 def noisy_simulator(request):
@@ -96,16 +96,16 @@ class TestQiskitSimulator(QuantumSimulatorTests):
             assert all(bitstring == (1, 0, 0) for bitstring in measurements.bitstrings)
 
     def test_setup_basic_simulators(self):
-        simulator = QiskitSimulator("qasm_simulator")
+        simulator = QiskitSimulator("aer_simulator")
         assert isinstance(simulator, QiskitSimulator)
-        assert simulator.device_name == "qasm_simulator"
+        assert simulator.device_name == "aer_simulator"
         assert simulator.noise_model is None
         assert simulator.device_connectivity is None
         assert simulator.basis_gates is None
 
-        simulator = QiskitSimulator("statevector_simulator")
+        simulator = QiskitSimulator("aer_simulator_statevector")
         assert isinstance(simulator, QiskitSimulator)
-        assert simulator.device_name == "statevector_simulator"
+        assert simulator.device_name == "aer_simulator_statevector"
         assert simulator.noise_model is None
         assert simulator.device_connectivity is None
         assert simulator.basis_gates is None
@@ -139,7 +139,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
         assert expectation_values_10_gates.values[0] > -1
         assert expectation_values_10_gates.values[0] < 0.0
         assert isinstance(noisy_simulator, QiskitSimulator)
-        assert noisy_simulator.device_name == "qasm_simulator"
+        assert noisy_simulator.device_name == "aer_simulator"
         assert isinstance(noisy_simulator.noise_model, AerNoise.NoiseModel)
         assert noisy_simulator.device_connectivity is not None
         assert noisy_simulator.basis_gates is not None
@@ -167,7 +167,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
             > expectation_values_10_gates.values[0]
         )
         assert isinstance(noisy_simulator, QiskitSimulator)
-        assert noisy_simulator.device_name == "qasm_simulator"
+        assert noisy_simulator.device_name == "aer_simulator"
         assert isinstance(noisy_simulator.noise_model, AerNoise.NoiseModel)
         assert noisy_simulator.device_connectivity is not None
         assert noisy_simulator.basis_gates is not None
@@ -179,7 +179,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
         )
         n_samples = 8192
         simulator = QiskitSimulator(
-            "qasm_simulator",
+            "aer_simulator",
             noise_model=noise_model,
             device_connectivity=connectivity,
             optimization_level=0,
@@ -213,8 +213,8 @@ class TestQiskitSimulator(QuantumSimulatorTests):
         # Given
         circuit = Circuit([X(0), CNOT(1, 2)])
         n_samples = 100
-        simulator1 = QiskitSimulator("qasm_simulator", seed=643)
-        simulator2 = QiskitSimulator("qasm_simulator", seed=643)
+        simulator1 = QiskitSimulator("aer_simulator", seed=643)
+        simulator2 = QiskitSimulator("aer_simulator", seed=643)
 
         # When
         measurements1 = simulator1.run_circuit_and_measure(circuit, n_samples)
@@ -227,8 +227,8 @@ class TestQiskitSimulator(QuantumSimulatorTests):
     def test_get_wavefunction_seed(self):
         # Given
         circuit = Circuit([X(0), CNOT(1, 2)])
-        simulator1 = QiskitSimulator("statevector_simulator", seed=643)
-        simulator2 = QiskitSimulator("statevector_simulator", seed=643)
+        simulator1 = QiskitSimulator("aer_simulator_statevector", seed=643)
+        simulator2 = QiskitSimulator("aer_simulator_statevector", seed=643)
 
         # When
         wavefunction1 = simulator1.get_wavefunction(circuit)


### PR DESCRIPTION
1. Updated qasm_simulator to aer_simulator. Note that this is only a change to qasm simulator that works locally. The remote simulator (IBMQ_qasm_simulator) is not depreciated. 
2. Updated statevector_simulator to aer_simulator_statevector. Also required that I add, circ.save_state() to each natively run circuit.