### PR TITLE
Hotfix assert list

### DIFF
--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -258,7 +258,7 @@ class QiskitBackend(QuantumBackend):
             A list of Measurements objects containing the observed bitstrings.
         """
 
-        assert isinstance(n_samples, list)
+        assert isinstance(n_samples, list) or isinstance(n_samples, tuple)
         assert isinstance(n_samples[0], int)
         (
             experiments,

--- a/src/python/qeqiskit/backend/backend.py
+++ b/src/python/qeqiskit/backend/backend.py
@@ -258,8 +258,6 @@ class QiskitBackend(QuantumBackend):
             A list of Measurements objects containing the observed bitstrings.
         """
 
-        assert isinstance(n_samples, list) or isinstance(n_samples, tuple)
-        assert isinstance(n_samples[0], int)
         (
             experiments,
             n_samples_for_experiments,


### PR DESCRIPTION
In `z-quantum-core`, the list of circuits and shots are [built as tuples, not lists](https://github.com/zapatacomputing/z-quantum-core/blob/5a464b9efcd06173781bb713f40286a5d0791eae/src/python/zquantum/core/estimation/_estimation.py#L315-L322), which caused problems with this assertion. Not sure if the best fix is to add `tuple` to the assertion like I did or change `z-quantum-core` to build lists instead.