### PR TITLE
Fixing a bug with 'ControlledGate() does not take any arguments'

### DIFF
--- a/src/python/qeqiskit/conversions/_circuit_conversions.py
+++ b/src/python/qeqiskit/conversions/_circuit_conversions.py
@@ -84,7 +84,9 @@ def _make_controlled_gate_prototype(wrapped_gate_ref, num_control_qubits=1):
 
 QISKIT_ZQUANTUM_GATE_MAP = {
     **{q_cls: z_ref for z_ref, q_cls in ZQUANTUM_QISKIT_GATE_MAP.items()},
-    qiskit.circuit.library.CSwapGate: _builtin_gates.SWAP.controlled(1),
+    qiskit.circuit.library.CRXGate: _make_controlled_gate_prototype(
+        _builtin_gates.SWAP
+    ),
     qiskit.circuit.library.CRXGate: _make_controlled_gate_prototype(_builtin_gates.RX),
     qiskit.circuit.library.CRYGate: _make_controlled_gate_prototype(_builtin_gates.RY),
     qiskit.circuit.library.CRZGate: _make_controlled_gate_prototype(_builtin_gates.RZ),

--- a/src/python/qeqiskit/conversions/_circuit_conversions.py
+++ b/src/python/qeqiskit/conversions/_circuit_conversions.py
@@ -84,7 +84,7 @@ def _make_controlled_gate_prototype(wrapped_gate_ref, num_control_qubits=1):
 
 QISKIT_ZQUANTUM_GATE_MAP = {
     **{q_cls: z_ref for z_ref, q_cls in ZQUANTUM_QISKIT_GATE_MAP.items()},
-    qiskit.circuit.library.CRXGate: _make_controlled_gate_prototype(
+    qiskit.circuit.library.CSwapGate: _make_controlled_gate_prototype(
         _builtin_gates.SWAP
     ),
     qiskit.circuit.library.CRXGate: _make_controlled_gate_prototype(_builtin_gates.RX),


### PR DESCRIPTION
This bug occured when transforming a complicated z-quantum-core circuit with `export_to_qiskit`.