### PR TITLE
feat(backend): readout correction for subset of qubits

### DIFF
--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -33,6 +33,14 @@ def backend(request):
             "n_samples_for_readout_calibration": 1,
             "retry_delay_seconds": 1,
         },
+        {
+            "device_name": "ibmq_qasm_simulator",
+            "api_token": os.getenv("ZAPATA_IBMQ_API_TOKEN"),
+            "readout_correction": True,
+            "n_samples_for_readout_calibration": 1,
+            "retry_delay_seconds": 1,
+            "noise_inversion_method": "pseudo_inverse",
+        },
     ]
 )
 def backend_with_readout_correction(request):

--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -264,7 +264,7 @@ class TestQiskitBackend(QuantumBackendTests):
         # Then
         assert backend_with_readout_correction.readout_correction
         assert (
-            backend_with_readout_correction.readout_correction_filters.get(str([0, 1]))
+            backend_with_readout_correction.readout_correction_filters.get(str([0, 5]))
             is not None
         )
         assert len(measurements_set) == num_circuits

--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -279,7 +279,6 @@ class TestQiskitBackend(QuantumBackendTests):
             ({"100000000000000000001": 10}, [0, 20]),
             ({"100000000000000000100": 10}, [0, 18, 20]),
             ({"001000000000000000001": 10}, [2, 20]),
-            ({"11": 10}, None),
         ],
     )
     def test_subset_readout_correction(
@@ -296,6 +295,24 @@ class TestQiskitBackend(QuantumBackendTests):
         assert backend_with_readout_correction.readout_correction
         assert backend_with_readout_correction.readout_correction_filters.get(
             str(active_qubits)
+        )
+        assert counts == pytest.approx(mitigated_counts, 10e-5)
+
+    def test_subset_readout_correction_with_unspecified_active_qubits(
+        self, backend_with_readout_correction
+    ):
+        # Given
+        counts = {"11": 10}
+
+        # When
+        mitigated_counts = backend_with_readout_correction._apply_readout_correction(
+            counts
+        )
+
+        # Then
+        assert backend_with_readout_correction.readout_correction
+        assert backend_with_readout_correction.readout_correction_filters.get(
+            str([0, 1])
         )
         assert counts == pytest.approx(mitigated_counts, 10e-5)
 

--- a/tests/qeqiskit/backend/backend_test.py
+++ b/tests/qeqiskit/backend/backend_test.py
@@ -1,5 +1,6 @@
 import math
 import os
+from copy import deepcopy
 
 import pytest
 import qiskit
@@ -41,7 +42,7 @@ def backend(request):
             "retry_delay_seconds": 1,
             "noise_inversion_method": "pseudo_inverse",
         },
-    ]
+    ],
 )
 def backend_with_readout_correction(request):
     return QiskitBackend(**request.param)
@@ -290,13 +291,14 @@ class TestQiskitBackend(QuantumBackendTests):
         ],
     )
     def test_subset_readout_correction(
-        self, backend_with_readout_correction, counts, active_qubits
+        self, counts, active_qubits, backend_with_readout_correction
     ):
         # Given
+        copied_counts = deepcopy(counts)
 
         # When
         mitigated_counts = backend_with_readout_correction._apply_readout_correction(
-            counts, active_qubits
+            copied_counts, active_qubits
         )
 
         # Then
@@ -304,7 +306,7 @@ class TestQiskitBackend(QuantumBackendTests):
         assert backend_with_readout_correction.readout_correction_filters.get(
             str(active_qubits)
         )
-        assert counts == pytest.approx(mitigated_counts, 10e-5)
+        assert copied_counts == pytest.approx(mitigated_counts, 10e-5)
 
     def test_subset_readout_correction_with_unspecified_active_qubits(
         self, backend_with_readout_correction


### PR DESCRIPTION
Implement readout error correction for less than the entire qubit register. Stores correction filters for each of the qubit indicies specified. Accurate up to 8 digits.